### PR TITLE
Fixed cleaning logic, chart addition, and export display issues

### DIFF
--- a/backend/templates/eda_report_template.html
+++ b/backend/templates/eda_report_template.html
@@ -3,12 +3,46 @@
 <head>
   <title>{{ title }}</title>
   <style>
-    body { font-family: Arial, sans-serif; color: #222; background: #fff; }
-    h1, h2 { color: #009688; }
-    table { border-collapse: collapse; width: 100%; margin-bottom: 1.5em; }
-    th, td { border: 1px solid #ccc; padding: 6px 10px; }
-    th { background: #f0f0f0; }
-    .section { margin-bottom: 2em; }
+    @page {
+      size: A4;
+      margin: 2cm;
+    }
+    body { 
+      font-family: Arial, sans-serif; 
+      color: #222; 
+      background: #fff;
+      margin: 0;
+      padding: 20px;
+    }
+    h1, h2 { 
+      color: #009688;
+      break-after: avoid;
+    }
+    table { 
+      border-collapse: collapse; 
+      width: 100%; 
+      margin-bottom: 1.5em;
+      page-break-inside: avoid;
+    }
+    th, td { 
+      border: 1px solid #ccc; 
+      padding: 6px 10px; 
+    }
+    th { 
+      background: #f0f0f0; 
+    }
+    .section { 
+      margin-bottom: 2em;
+      page-break-inside: avoid;
+    }
+    .chart-container {
+      page-break-inside: avoid;
+      margin-bottom: 2em;
+    }
+    img {
+      max-width: 100% !important;
+      height: auto !important;
+    }
   </style>
 </head>
 <body>
@@ -79,11 +113,11 @@
   <div class="section">
     <h2>Visualisations</h2>
     {% for chart in charts %}
-      <div>
+      <div class="chart-container">
         <h3>{{ chart.title }}</h3>
-        <p>Type: {{ chart.type }} | Columns: {{ chart.columns }}</p>
+        <p>Type: {{ chart.type }} | Columns: {{ chart.columns }}{% if chart.aggregationType %} | Aggregation: {{ chart.aggregationType }}{% endif %}</p>
         <p>{{ chart.insight }}</p>
-        <img src="data:image/png;base64,{{ chart.image_base64 }}" alt="{{ chart.title }}" style="max-width: 600px;"/>
+        <img src="data:image/png;base64,{{ chart.image_base64 }}" alt="{{ chart.title }}"/>
       </div>
     {% endfor %}
   </div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, createContext } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import { AppBar, Toolbar, Typography, Button, IconButton, Box } from '@mui/material';
 import { Link } from 'react-router-dom';
@@ -8,6 +8,8 @@ import AssessmentIcon from '@mui/icons-material/Assessment';
 import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
 import InsightsIcon from '@mui/icons-material/Insights';
 import SaveAltIcon from '@mui/icons-material/SaveAlt';
+
+export const CleaningSummaryContext = createContext();
 
 const navItems = [
   { label: 'Upload', link: '/upload', icon: <UploadFileIcon /> },
@@ -19,9 +21,10 @@ const navItems = [
 
 function App() {
   const location = useLocation();
+  const [cleaningSummary, setCleaningSummary] = useState([]);
 
   return (
-    <>
+    <CleaningSummaryContext.Provider value={{ cleaningSummary, setCleaningSummary }}>
       <AppBar position="static" sx={{ backgroundColor: '#004d40', boxShadow: 'none' }}>
         <Toolbar>
           <IconButton
@@ -74,7 +77,7 @@ function App() {
       </AppBar>
       {/* This renders the matched child route */}
       <Outlet />
-    </>
+    </CleaningSummaryContext.Provider>
   );
 }
 

--- a/frontend/src/ChartsToReportContext.jsx
+++ b/frontend/src/ChartsToReportContext.jsx
@@ -1,0 +1,14 @@
+import React, { createContext, useState, useContext } from 'react';
+
+const ChartsToReportContext = createContext();
+
+export const useChartsToReport = () => useContext(ChartsToReportContext);
+
+export const ChartsToReportProvider = ({ children }) => {
+  const [chartsToReport, setChartsToReport] = useState({});
+  return (
+    <ChartsToReportContext.Provider value={{ chartsToReport, setChartsToReport }}>
+      {children}
+    </ChartsToReportContext.Provider>
+  );
+}; 

--- a/frontend/src/UploadPage.jsx
+++ b/frontend/src/UploadPage.jsx
@@ -1,14 +1,16 @@
-import { useState } from 'react';
+import { useState, useContext } from 'react';
 import { Box, Button, Typography, Paper, InputLabel, Divider, Grid } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
+import { CleaningSummaryContext } from './App';
 
 function UploadPage() {
   const [file, setFile] = useState(null);
   const [uploading, setUploading] = useState(false);
   const navigate = useNavigate();
+  const { setCleaningSummary } = useContext(CleaningSummaryContext);
 
   const handleFileChange = (e) => {
     setFile(e.target.files[0]);
@@ -19,8 +21,8 @@ function UploadPage() {
     setUploading(true);
 
     // Clear cleaning state when a new file is uploaded
-    localStorage.removeItem('hasCleaned');
-    localStorage.removeItem('cleanedData');
+    localStorage.removeItem('cleaningSession');
+    // (Do NOT clear cleaningSummary here)
 
     const formData = new FormData();
     formData.append('dataset', file);
@@ -32,6 +34,7 @@ function UploadPage() {
         credentials: 'include',
       });
       if (res.ok) {
+        localStorage.removeItem('cleaningSession'); // Reset localStorage
         navigate('/report'); // Redirect to the report page after successful upload
       } else {
         alert('Upload failed');

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -10,15 +10,16 @@ import ReportPage from './ReportPage';
 import CleaningPage from './CleaningPage';
 import AnalysisPage from './AnalysisPage';
 import ExportPage from './ExportPage';
+import { ChartsToReportProvider } from './ChartsToReportContext';
 
 const darkTheme = createTheme({
   palette: {
     mode: 'dark',
-    primary: { main: '#009688' },    // teal
-    secondary: { main: '#e91e63' },  // pink
+    primary: { main: '#009688' },
+    secondary: { main: '#e91e63' },
     background: {
-      default: '#121212',            // dark background
-      paper: '#1e1e1e',              // dark card/paper
+      default: '#121212',
+      paper: '#1e1e1e',
     },
   },
 });
@@ -57,21 +58,8 @@ function MainRouter() {
             <Route path="upload" element={<UploadPage />} />
             <Route path="report" element={<ReportPage />} />
             <Route path="cleaning" element={<CleaningPage />} />
-            <Route path="/analysis" element={<AnalysisPage chartsToReport={chartsToReport} setChartsToReport={setChartsToReport} />} />
-            <Route path="/export" element={
-              <ExportPage
-                chartsToReport={chartsToReport}
-                setChartsToReport={setChartsToReport}
-                includedSections={includedSections}
-                onSectionToggle={handleSectionToggle}
-                downloadCleaned={downloadCleaned}
-                onDownloadCleanedChange={handleDownloadCleanedChange}
-                reportTitle={reportTitle}
-                onTitleChange={setReportTitle}
-              />
-            } />
-            {/* <Route path="analysis" element={<AnalysisPage />} /> */} {/* Removed */}
-            {/* Add more routes as needed */}
+            <Route path="analysis" element={<AnalysisPage />} />
+            <Route path="export" element={<ExportPage />} />
           </Route>
         </Routes>
       </BrowserRouter>
@@ -80,5 +68,9 @@ function MainRouter() {
 }
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <MainRouter />
+  <React.StrictMode>
+    <ChartsToReportProvider>
+      <MainRouter />
+    </ChartsToReportProvider>
+  </React.StrictMode>
 );


### PR DESCRIPTION
- Fixed issue where cleaning required action for all columns
- Added "Keep nulls" option for clarity
- Updated outlier count and dataset shape after cleaning
- Implemented dynamic cleaning summary
- Reset outliers dropdown after each cleaning pass
- Fixed "Add to charts" logic and integrated aggregation
- Resolved visualisations not updating correctly on export page

TODO: Fix cleaning/outliers summary in export report preview